### PR TITLE
add image pooling

### DIFF
--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -29,6 +29,7 @@ package decoder
 */
 import "C"
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"image"
@@ -47,22 +48,22 @@ type Decoder struct {
 	sPtr    C.size_t
 }
 
-// NewDecoder return new decoder instance
 func NewDecoder(r io.Reader, options *Options) (d *Decoder, err error) {
-	var data []byte
-
-	if data, err = io.ReadAll(r); err != nil {
-		return nil, err
-	}
-
-	if len(data) == 0 {
-		return nil, errors.New("data is empty")
-	}
-
 	if options == nil {
 		options = &Options{}
 	}
-	d = &Decoder{data: data, options: options}
+
+	if options.imageFactory == nil {
+		options.imageFactory = &DefaultImageFactory{}
+	}
+
+	buf := bytes.NewBuffer(options.buffer)
+
+	if _, err = io.Copy(buf, r); err != nil {
+		return nil, err
+	}
+
+	d = &Decoder{data: buf.Bytes(), options: options}
 
 	if d.config, err = d.options.GetConfig(); err != nil {
 		return nil, err
@@ -87,10 +88,7 @@ func (d *Decoder) Decode() (image.Image, error) {
 	d.config.output.colorspace = C.MODE_RGBA
 	d.config.output.is_external_memory = 1
 
-	img := image.NewNRGBA(image.Rectangle{Max: image.Point{
-		X: int(d.config.output.width),
-		Y: int(d.config.output.height),
-	}})
+	img := d.options.imageFactory.Get(int(d.config.output.width), int(d.config.output.height))
 
 	buff := (*C.WebPRGBABuffer)(unsafe.Pointer(&d.config.output.u[0]))
 	buff.stride = C.int(img.Stride)

--- a/decoder/decoder.go
+++ b/decoder/decoder.go
@@ -63,6 +63,10 @@ func NewDecoder(r io.Reader, options *Options) (d *Decoder, err error) {
 		return nil, err
 	}
 
+	if len(buf.Bytes()) == 0 {
+		return nil, errors.New("data is empty")
+	}
+
 	d = &Decoder{data: buf.Bytes(), options: options}
 
 	if d.config, err = d.options.GetConfig(); err != nil {

--- a/decoder/decoder_benchmark_test.go
+++ b/decoder/decoder_benchmark_test.go
@@ -5,8 +5,6 @@ import (
 	"image"
 	"os"
 	"testing"
-
-	"github.com/kolesa-team/go-webp/pool"
 )
 
 func loadImage(b *testing.B) []byte {
@@ -24,8 +22,8 @@ func BenchmarkDecodePooled(b *testing.B) {
 
 	data := loadImage(b)
 
-	imagePool := pool.NewSimplePool()
-	bufferPool := pool.NewBufferPool()
+	imagePool := NewImagePool()
+	bufferPool := NewBufferPool()
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {

--- a/decoder/decoder_benchmark_test.go
+++ b/decoder/decoder_benchmark_test.go
@@ -9,32 +9,8 @@ import (
 	"github.com/kolesa-team/go-webp/pool"
 )
 
-func BenchmarkDecodeOneSizeOnly(b *testing.B) {
-	b.ResetTimer()
-	b.ReportAllocs()
-
-	data := loadImage(b)
-
-	nrgbaPool := pool.NewNRGBAOneSizePool(512, 512)
-	bufferPool := pool.NewBufferPool(512 * 512)
-
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			buf := bufferPool.Get()
-			decoder, err := NewDecoder(bytes.NewReader(data), &Options{imageFactory: nrgbaPool, buffer: buf})
-			img, err := decoder.Decode()
-			if err != nil {
-				b.Fatal(err)
-			}
-			nrgbaPool.Put(img.(*image.NRGBA))
-			bufferPool.Put(buf)
-		}
-	})
-}
-
 func loadImage(b *testing.B) []byte {
 	filename := "../test_data/images/100x150_lossless.webp"
-	// filename := "../test_data/images/composite.webp"
 	data, err := os.ReadFile(filename)
 	if err != nil {
 		b.Fatal(err)
@@ -42,30 +18,32 @@ func loadImage(b *testing.B) []byte {
 	return data
 }
 
-func BenchmarkDecodeAnySize(b *testing.B) {
+func BenchmarkDecodePooled(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 
 	data := loadImage(b)
 
-	nrgbaPool := pool.NewNRGBAMultiPool()
-	bufferPool := pool.NewBufferPool(512 * 512)
+	imagePool := pool.NewSimplePool()
+	bufferPool := pool.NewBufferPool()
 
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			buf := bufferPool.Get()
-			decoder, err := NewDecoder(bytes.NewReader(data), &Options{imageFactory: nrgbaPool, buffer: buf})
+			decoder, err := NewDecoder(bytes.NewReader(data), &Options{imageFactory: imagePool, buffer: buf})
 			img, err := decoder.Decode()
 			if err != nil {
 				b.Fatal(err)
 			}
-			nrgbaPool.Put(img.(*image.NRGBA))
+
+			// put everything back
+			imagePool.Put(img.(*image.NRGBA))
 			bufferPool.Put(buf)
 		}
 	})
 }
 
-func BenchmarkDecodeOriginal(b *testing.B) {
+func BenchmarkDecodeUnPooled(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 

--- a/decoder/decoder_benchmark_test.go
+++ b/decoder/decoder_benchmark_test.go
@@ -1,0 +1,84 @@
+package decoder
+
+import (
+	"bytes"
+	"image"
+	"os"
+	"testing"
+
+	"github.com/kolesa-team/go-webp/pool"
+)
+
+func BenchmarkDecodeOneSizeOnly(b *testing.B) {
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	data := loadImage(b)
+
+	nrgbaPool := pool.NewNRGBAOneSizePool(512, 512)
+	bufferPool := pool.NewBufferPool(512 * 512)
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			buf := bufferPool.Get()
+			decoder, err := NewDecoder(bytes.NewReader(data), &Options{imageFactory: nrgbaPool, buffer: buf})
+			img, err := decoder.Decode()
+			if err != nil {
+				b.Fatal(err)
+			}
+			nrgbaPool.Put(img.(*image.NRGBA))
+			bufferPool.Put(buf)
+		}
+	})
+}
+
+func loadImage(b *testing.B) []byte {
+	filename := "../test_data/images/100x150_lossless.webp"
+	// filename := "../test_data/images/composite.webp"
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		b.Fatal(err)
+	}
+	return data
+}
+
+func BenchmarkDecodeAnySize(b *testing.B) {
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	data := loadImage(b)
+
+	nrgbaPool := pool.NewNRGBAMultiPool()
+	bufferPool := pool.NewBufferPool(512 * 512)
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			buf := bufferPool.Get()
+			decoder, err := NewDecoder(bytes.NewReader(data), &Options{imageFactory: nrgbaPool, buffer: buf})
+			img, err := decoder.Decode()
+			if err != nil {
+				b.Fatal(err)
+			}
+			nrgbaPool.Put(img.(*image.NRGBA))
+			bufferPool.Put(buf)
+		}
+	})
+}
+
+func BenchmarkDecodeOriginal(b *testing.B) {
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	data := loadImage(b)
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			decoder, err := NewDecoder(bytes.NewReader(data), &Options{})
+			img, err := decoder.Decode()
+			if err != nil {
+				b.Fatal(err)
+			}
+			_ = img
+		}
+	})
+}

--- a/decoder/decoder_test.go
+++ b/decoder/decoder_test.go
@@ -22,11 +22,12 @@
 package decoder
 
 import (
-	"github.com/kolesa-team/go-webp/utils"
-	"github.com/stretchr/testify/require"
 	"image"
 	"os"
 	"testing"
+
+	"github.com/kolesa-team/go-webp/utils"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewDecoder(t *testing.T) {

--- a/decoder/options.go
+++ b/decoder/options.go
@@ -43,8 +43,14 @@ type Options struct {
 	AlphaDitheringStrength int
 
 	// These two are optimizations that require a little extra work on the caller side.
-	imageFactory ImageFactory // if nil, DefaultImageFactory will be used
-	buffer       []byte       // temp buffer to store data from reader.  If nil, default buffer will be used
+
+	// if nil, DefaultImageFactory will be used.  If non-nil, decode will return an image that must be put back into the pool
+	// when you're done with it
+	imageFactory ImageFactory
+	// if nil, a default buffer will be used.  If non-nil, decode will use this buffer to store data from the reader.
+	// The idea is that this buffer be reused, so either pass this back in next time you call decode, or put it back into
+	// a pool when you're done with it.
+	buffer []byte
 }
 
 // GetConfig build WebPDecoderConfig for libwebp

--- a/decoder/options.go
+++ b/decoder/options.go
@@ -41,6 +41,10 @@ type Options struct {
 	Flip                   bool
 	DitheringStrength      int
 	AlphaDitheringStrength int
+
+	// These two are optimizations that require a little extra work on the caller side.
+	imageFactory ImageFactory // if nil, DefaultImageFactory will be used
+	buffer       []byte       // temp buffer to store data from reader.  If nil, default buffer will be used
 }
 
 // GetConfig build WebPDecoderConfig for libwebp
@@ -88,4 +92,14 @@ func (o *Options) GetConfig() (*C.WebPDecoderConfig, error) {
 	config.options.alpha_dithering_strength = C.int(o.AlphaDitheringStrength)
 
 	return &config, nil
+}
+
+type ImageFactory interface {
+	Get(width, height int) *image.NRGBA
+}
+
+type DefaultImageFactory struct{}
+
+func (d *DefaultImageFactory) Get(width, height int) *image.NRGBA {
+	return image.NewNRGBA(image.Rect(0, 0, width, height))
 }

--- a/decoder/pool.go
+++ b/decoder/pool.go
@@ -1,0 +1,75 @@
+package decoder
+
+import (
+	"image"
+	"sync"
+	"sync/atomic"
+)
+
+type ImagePool struct {
+	poolMap map[int]*sync.Pool
+	lock    *sync.Mutex
+	Count   int64
+}
+
+func NewImagePool() *ImagePool {
+	return &ImagePool{
+		poolMap: make(map[int]*sync.Pool),
+		lock:    &sync.Mutex{},
+	}
+}
+
+func (n *ImagePool) Get(width, height int) *image.NRGBA {
+	dimPool := n.getPool(width, height)
+
+	img := dimPool.Get().(*image.NRGBA)
+	img.Rect.Max.X = width
+	img.Rect.Max.Y = height
+	return img
+}
+
+func (n *ImagePool) getPool(width int, height int) *sync.Pool {
+	dim := width * height
+
+	n.lock.Lock()
+	dimPool, ok := n.poolMap[dim]
+	if !ok {
+		atomic.AddInt64(&n.Count, 1)
+		dimPool = &sync.Pool{
+			New: func() interface{} {
+				return image.NewNRGBA(image.Rect(0, 0, width, height))
+			},
+		}
+		n.poolMap[dim] = dimPool
+	}
+	n.lock.Unlock()
+	return dimPool
+}
+
+func (n *ImagePool) Put(img *image.NRGBA) {
+	dimPool := n.getPool(img.Rect.Dx(), img.Rect.Dy())
+	dimPool.Put(img)
+}
+
+type BufferPool struct {
+	pool *sync.Pool // pointer because noCopy
+}
+
+func NewBufferPool() *BufferPool {
+	return &BufferPool{
+		pool: &sync.Pool{
+			New: func() interface{} {
+				return make([]byte, 0, 1024)
+			},
+		},
+	}
+}
+
+func (b *BufferPool) Get() []byte {
+	return b.pool.Get().([]byte)
+}
+
+func (b *BufferPool) Put(buf []byte) {
+	buf = buf[:0]
+	b.pool.Put(buf)
+}


### PR DESCRIPTION
Now you can pass in an ImageFactory and a buffer to be used in the encoding process for huge efficiency gains:
```
BenchmarkDecodePooled
BenchmarkDecodePooled-10      	  355448	      3650 ns/op	     581 B/op	       6 allocs/op
BenchmarkDecodeUnPooled
BenchmarkDecodeUnPooled-10    	   99817	     11573 ns/op	   66210 B/op	       8 allocs/op
```